### PR TITLE
Add functionality to control the store credit card switch state

### DIFF
--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -168,6 +168,10 @@ public class CardComponent: PublicKeyConsumer,
     public func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         cardViewController.update(storePaymentMethodFieldVisibility: isVisible)
     }
+
+    public func update(storePaymentMethodFieldValue isOn: Bool) {
+        cardViewController.update(storePaymentMethodFieldValue: isOn)
+    }
     // MARK: - Form Items
     
     private lazy var securedViewController = SecuredViewController(child: cardViewController, style: style)

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -301,8 +301,10 @@ extension FormValueItem where ValueType == String {
 
 extension CardViewController: CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool) {
-        guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
-        storeDetailsItem.isVisible = isVisible
+        if !isVisible {
+            items.storeDetailsItem.value = false
+        }
+        items.storeDetailsItem.isVisible = isVisible
     }
 
     func update(storePaymentMethodFieldValue isOn: Bool) {

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -302,7 +302,6 @@ extension FormValueItem where ValueType == String {
 extension CardViewController: CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
-        items.storeDetailsItem.value = false
         storeDetailsItem.isVisible = isVisible
     }
 

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 
 protocol CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool)
+    func update(storePaymentMethodFieldValue isOn: Bool)
 }
 
 internal class CardViewController: FormViewController {
@@ -303,5 +304,9 @@ extension CardViewController: CardViewControllerProtocol {
         guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
         items.storeDetailsItem.value = false
         storeDetailsItem.isVisible = isVisible
+    }
+
+    func update(storePaymentMethodFieldValue isOn: Bool) {
+        items.storeDetailsItem.value = isOn
     }
 }


### PR DESCRIPTION
This PR adds the functionality to control the store credit card switch state without the need for user input.