### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cancel-multiple-workflow-runs:
     name: "Cancel the self CI workflow run"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - name: "Cancel build"
         uses: potiuk/cancel-workflow-runs@master

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -2,7 +2,7 @@ name: Get Release notes
 on: [workflow_dispatch]
 jobs:
   release_notes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - name: Fetch repo
         uses: actions/checkout@v3

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   get-pr-labels:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - name: Fetch repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
