### PR TITLE
Pin versions of GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
           needs_custom_sim: true
           
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -9,49 +9,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Cancel build"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: build.yml
       - name: "Cancel pr scan"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: pr_scan.yml
       - name: "Cancel spell check"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: spell-check.yml
       - name: "Cancel test_cocoapods_integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: test_cocoapods_integration.yml
       - name: "Cancel test-carthage-integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: test-carthage-integration.yml
       - name: "Cancel test-SPM-integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           workflowFileName: test-SPM-integration.yml
       - name: "Cancel validate_pr_labels_and_release_notes"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: potiuk/cancel-workflow-runs@e9e87cb7738dbb999654aa90d69359d62c9e4eae # v3
         with:
           cancelMode: allDuplicates
           cancelFutureDuplicates: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,13 +6,13 @@ jobs:
   Deploy:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -21,14 +21,14 @@ jobs:
       id: get-current-marketing-version
 
     - name: Deploy to current version 🚀
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/html
         destination_dir: ./${{ steps.get-current-marketing-version.outputs.MARKETING_VERSION }}
         
     - name: Deploy to root 🚀
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/redirect

--- a/.github/workflows/format_project.yml
+++ b/.github/workflows/format_project.yml
@@ -5,15 +5,15 @@ jobs:
   Update:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -22,7 +22,7 @@ jobs:
         brew install swiftformat
         swiftformat .
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
       with:
         delete-branch: true
         branch: format-project-github-action

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Get the list of allowed pull request labels

--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: macos-13-xlarge # Apple Silicon Runner
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         
@@ -30,7 +30,7 @@ jobs:
         Scripts/validate-Adyen-SDK-version.sh
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: '15.1'
 

--- a/.github/workflows/publich_podspec.yml
+++ b/.github/workflows/publich_podspec.yml
@@ -5,10 +5,10 @@ jobs:
   publish:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -5,15 +5,15 @@ jobs:
   Publish:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -10,15 +10,15 @@ jobs:
   Generate:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -28,7 +28,7 @@ jobs:
       env:
         LATEST_VERSION: ${{ github.event.inputs.latestVersion }}
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
       with:
         delete-branch: true
         branch: update-docs-github-action

--- a/.github/workflows/regenerate-snapshots.yml
+++ b/.github/workflows/regenerate-snapshots.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: macos-13-xlarge
     
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: 🔨 Select Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: '15.1'
 
@@ -29,7 +29,7 @@ jobs:
         scheme: 'GenerateSnapshots'
         
     - name: 🚀 Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
       with:
         delete-branch: true
         branch: update-snapshots-github-action

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -9,10 +9,10 @@ jobs:
   setup:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -13,13 +13,13 @@ jobs:
   SPM:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -13,13 +13,13 @@ jobs:
   carthage:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -13,13 +13,13 @@ jobs:
   pods:
     runs-on: macos-12-xl
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 

--- a/.github/workflows/test_library_evolution.yml
+++ b/.github/workflows/test_library_evolution.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: macos-13-xl
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: '14.3'
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -10,15 +10,15 @@ jobs:
   Update:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v3
+    - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -26,7 +26,7 @@ jobs:
       run: |
         Scripts/increment_version.sh ${{ github.event.inputs.newVersion }}
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
       with:
         delete-branch: true
         branch: update-version-github-action

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -29,13 +29,13 @@ jobs:
           PROJECT_ROOT: ${{ github.workspace }}
 
       - name: Validate labels
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401 # v1.4.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
 
       - name: Get PR labels
-        uses: joerick/pr-labels-action@v1.0.9
+        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # v1.0.9
         id: pr-labels
 
       - run: |


### PR DESCRIPTION
### Summary
This pull request pins the versions of GitHub Actions used in the CI/CD workflows to specific commit SHAs or tagged releases. It modifies several workflow files under the `.github/workflows/` directory, specifying fixed versions for actions such as `actions/checkout`, `n1hility/cancel-previous-runs`, `potiuk/cancel-workflow-runs`, `maxim-lobanov/setup-xcode`, and others.

### Purpose
Pinning action versions ensures consistent, reproducible CI builds by avoiding unintended updates or breaking changes from floating action versions.

### Scope
- Modifications are limited to workflow yaml configuration files.
- No application source code or business logic is changed.

This change improves stability and predictability of the CI pipeline without impacting the app's runtime behavior or features.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->